### PR TITLE
Updated pom version to move past broken release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.common</groupId>
   <artifactId>framework</artifactId>
-  <version>10.49.7-SNAPSHOT</version>
+  <version>10.49.8-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Common Framework</name>


### PR DESCRIPTION
There was already a framework-10.49.7 tag in git when travis came to release this (on account of aborted local release last week).  Easiest thing at this point is to push on past the broken version (easier than trying to unpick the last release).