### PR TITLE
Adding logging to investigate READY_TO_REVIEW state change issue

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -40,12 +40,12 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
       destinationState = outputMap.get(event);
     }
     if (destinationState == null) {
-    	log.error("No valid transition found from " + sourceState.getClass().getName() 
+    	log.error("No valid transition found from " + sourceState.getClass().getName()
     			+ " using " + event.getClass().getName());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     } else {
-    	log.info("Moving from " + sourceState.getClass().getName() 
-    			+ " to " + destinationState.getClass().getName() 
+    	log.info("Moving from " + sourceState.getClass().getName()
+    			+ " to " + destinationState.getClass().getName()
     			+ " due to " + event.getClass().getName());
     }
     return destinationState;

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -39,14 +39,14 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
     if (outputMap != null) {
       destinationState = outputMap.get(event);
     }
-    if (destinationState == null) {
-      log.warn("No valid transition found from " + sourceState.getClass().getName()
-          + " using " + event.getClass().getName());
+    if (destinationState == null || destinationState.equals(sourceState)) {
+      log.warn("No valid transition found from " + sourceState.toString()
+          + " using " + event.toString());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     } else {
-      log.info("Moving from " + sourceState.getClass().getName()
-          + " to " + destinationState.getClass().getName()
-          + " due to " + event.getClass().getName());
+      log.info("Moving from " + sourceState.toString()
+          + " to " + destinationState.toString()
+          + " due to " + event.toString());
     }
     return destinationState;
   }

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -40,10 +40,13 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
       destinationState = outputMap.get(event);
     }
     if (destinationState == null) {
-    	log.error("No valid transition found from " + sourceState.getClass().getName() + " using " + event.getClass().getName());
+    	log.error("No valid transition found from " + sourceState.getClass().getName() 
+    			+ " using " + event.getClass().getName());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     } else {
-    	log.info("Moving from " + sourceState.getClass().getName() + " to " + destinationState.getClass().getName() + " due to " + event.getClass().getName());
+    	log.info("Moving from " + sourceState.getClass().getName() 
+    			+ " to " + destinationState.getClass().getName() 
+    			+ " due to " + event.getClass().getName());
     }
     return destinationState;
   }

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -40,13 +40,13 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
       destinationState = outputMap.get(event);
     }
     if (destinationState == null) {
-    	log.error("No valid transition found from " + sourceState.getClass().getName()
-    			+ " using " + event.getClass().getName());
+      log.error("No valid transition found from " + sourceState.getClass().getName()
+          + " using " + event.getClass().getName());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     } else {
-    	log.info("Moving from " + sourceState.getClass().getName()
-    			+ " to " + destinationState.getClass().getName()
-    			+ " due to " + event.getClass().getName());
+      log.info("Moving from " + sourceState.getClass().getName()
+          + " to " + destinationState.getClass().getName()
+          + " due to " + event.getClass().getName());
     }
     return destinationState;
   }

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.common.state;
 
 import lombok.Data;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.ons.ctp.common.error.CTPException;
 
 import java.util.Collections;
@@ -14,6 +15,7 @@ import java.util.Map;
  * @param <S> The state type we transit from and to
  * @param <E> The event type that effects the transition
  */
+@Slf4j
 @Data
 @Getter
 public class BasicStateTransitionManager<S, E> implements StateTransitionManager<S, E> {

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -40,7 +40,7 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
       destinationState = outputMap.get(event);
     }
     if (destinationState == null) {
-      log.error("No valid transition found from " + sourceState.getClass().getName()
+      log.warn("No valid transition found from " + sourceState.getClass().getName()
           + " using " + event.getClass().getName());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     } else {

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -36,8 +36,10 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
     Map<E, S> outputMap = transitions.get(sourceState);
     if (outputMap != null) {
       destinationState = outputMap.get(event);
+      log.info("Moving from " + sourceState.getClass().getName() + " to " + destinationState.getClass().getName() + " due to " + event.getClass().getName());
     }
     if (destinationState == null) {
+    	log.error("No valid transition found from " + sourceState.getClass().getName() + " using " + event.getClass().getName());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     }
     return destinationState;

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -39,7 +39,7 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
     if (outputMap != null) {
       destinationState = outputMap.get(event);
     }
-    if (destinationState == null || destinationState.equals(sourceState)) {
+    if (destinationState == null) {
       log.warn("No valid transition found from " + sourceState.toString()
           + " using " + event.toString());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));

--- a/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/uk/gov/ons/ctp/common/state/BasicStateTransitionManager.java
@@ -38,11 +38,12 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
     Map<E, S> outputMap = transitions.get(sourceState);
     if (outputMap != null) {
       destinationState = outputMap.get(event);
-      log.info("Moving from " + sourceState.getClass().getName() + " to " + destinationState.getClass().getName() + " due to " + event.getClass().getName());
     }
     if (destinationState == null) {
     	log.error("No valid transition found from " + sourceState.getClass().getName() + " using " + event.getClass().getName());
       throw new CTPException(CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
+    } else {
+    	log.info("Moving from " + sourceState.getClass().getName() + " to " + destinationState.getClass().getName() + " due to " + event.getClass().getName());
     }
     return destinationState;
   }


### PR DESCRIPTION
This just adds logging to state transitions to ensure that if the READY_TO_REVIEW issue is reproducible, we can catch it.

This is a first step agreed in standup. If it doesn't suffice, we can go further to things like audit tables and the like.