### PR TITLE
Add Support for JSR310 date API in Jackson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     fi
   - cp .travis.settings.xml $HOME/.m2/settings.xml
   - curl ifconfig.co|xargs echo "Travis IP address is ";
+  - export TZ=Europe/London
 
 script:
   - mvn test -B

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,22 @@
       <artifactId>spring-rabbit</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-parameter-names</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.common.jackson;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
 
 /** Custom Object Mapper */
@@ -11,5 +12,7 @@ public class CustomObjectMapper extends ObjectMapper {
   public CustomObjectMapper() {
     this.setDateFormat(new MultiIsoDateFormat());
     this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    this.registerModule(new JavaTimeModule());
+    this.findAndRegisterModules();
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapperTest.java
@@ -1,0 +1,76 @@
+package uk.gov.ons.ctp.common.jackson;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import org.junit.Test;
+
+/** Test for common custom object mapper */
+public class CustomObjectMapperTest {
+
+  private static final long EPOCH_MS = 1532695775000L;
+  private static final Instant EPOCH_INSTANT = Instant.ofEpochMilli(EPOCH_MS);
+  private static final Date FRI_27_JULY_DATE = Date.from(EPOCH_INSTANT);
+  private static final ZoneOffset ZONE_BST = ZoneOffset.ofHours(1);
+  private static final OffsetDateTime FRI_27_JULY_OFFSET_DATE_TIME =
+      OffsetDateTime.ofInstant(EPOCH_INSTANT, ZONE_BST);
+  private static final String FRI_27_JULY_JSON_ISO_WITH_MS = "\"2018-07-27T13:49:35.000+01:00\"";
+  private static final String FRI_27_JULY_JSON_ISO = "\"2018-07-27T13:49:35+01:00\"";
+
+  static class SerializableObject {
+    boolean ok = true;
+  }
+
+  @Test
+  public void testMapperIsConfiguredToWriteIsoDatesFromDate() throws JsonProcessingException {
+    final CustomObjectMapper objectMapper = new CustomObjectMapper();
+
+    assertThat(objectMapper.writeValueAsString(FRI_27_JULY_DATE), is(FRI_27_JULY_JSON_ISO_WITH_MS));
+  }
+
+  @Test
+  public void testMapperIsConfiguredToReadIsoDatesToDate() throws IOException {
+    final CustomObjectMapper objectMapper = new CustomObjectMapper();
+
+    assertThat(
+        objectMapper.readValue(FRI_27_JULY_JSON_ISO_WITH_MS, Date.class), is(FRI_27_JULY_DATE));
+  }
+
+  @Test
+  public void testMapperIsConfiguredToWriteIsoDatesFromOffsetDateTime()
+      throws JsonProcessingException {
+    final CustomObjectMapper objectMapper = new CustomObjectMapper();
+
+    assertThat(
+        objectMapper.writeValueAsString(FRI_27_JULY_OFFSET_DATE_TIME), is(FRI_27_JULY_JSON_ISO));
+  }
+
+  @Test
+  public void testMapperIsConfiguredToReadIsoDatesToOffsetDateTime() throws IOException {
+    final CustomObjectMapper objectMapper = new CustomObjectMapper();
+
+    OffsetDateTime offsetDateTime =
+        objectMapper.readValue(FRI_27_JULY_JSON_ISO, OffsetDateTime.class);
+
+    long actualEpochMs = offsetDateTime.toInstant().toEpochMilli();
+    long expectedEpochMs = FRI_27_JULY_OFFSET_DATE_TIME.toInstant().toEpochMilli();
+
+    assertThat(actualEpochMs, is(expectedEpochMs));
+  }
+
+  @Test
+  public void testMapperIsConfiguredToSkipUnknownProperties() throws IOException {
+    final CustomObjectMapper objectMapper = new CustomObjectMapper();
+
+    assertThat(
+        objectMapper.readValue("{ \"ok\": true, \"skipped\": true }", SerializableObject.class),
+        is(instanceOf(SerializableObject.class)));
+  }
+}


### PR DESCRIPTION
Currently you can only use the old date API. The new date API (since
1.8) requires some configuration. This adds that configuration.

This supports a TBL123 ticket.


<!--- Why is this change required? What problem does it solve? -->

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->