### PR TITLE
Create method for http entity with auth

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/rest/RestUtility.java
+++ b/src/main/java/uk/gov/ons/ctp/common/rest/RestUtility.java
@@ -51,24 +51,38 @@ public class RestUtility {
     // Have to build UriComponents for query parameters separately as Expand interprets braces in
     // JSON query string
     // values as URI template variables to be replaced.
-    UriComponents uriComponents =
-        UriComponentsBuilder.newInstance()
-            .uriComponents(uriComponentsWithOutQueryParams)
-            .queryParams(queryParams)
-            .build()
-            .encode();
 
-    return uriComponents;
+    return UriComponentsBuilder.newInstance()
+        .uriComponents(uriComponentsWithOutQueryParams)
+        .queryParams(queryParams)
+        .build()
+        .encode();
   }
 
   /**
-   * Creates a Http Entity
+   * Creates a {@link HttpEntity} with basic auth header and application/json set for
+   * Content-Type and Accept
+   *
+   * @param <H> generic passed in for body content
+   * @return HttpEntity containing object as JSON
+   */
+  public <H> HttpEntity<H> createHttpEntityWithAuthHeader() {
+    return new HttpEntity<>(getHttpHeaders());
+  }
+
+  /**
+   * Creates a {@link HttpEntity} with basic authentication header and application/json set for
+   * Content-Type and Accept
    *
    * @param entity entity to be created from
    * @param <H> generic passed in for body content
    * @return HttpEntity containing object as JSON
    */
   public <H> HttpEntity<H> createHttpEntity(H entity) {
+    return new HttpEntity<>(entity, getHttpHeaders());
+  }
+
+  private HttpHeaders getHttpHeaders() {
     HttpHeaders headers = new HttpHeaders();
     headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
     headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
@@ -79,8 +93,6 @@ public class RestUtility {
       String authHeader = "Basic " + new String(encodedAuth);
       headers.set("Authorization", authHeader);
     }
-
-    HttpEntity<H> httpEntity = new HttpEntity<H>(entity, headers);
-    return httpEntity;
+    return headers;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/rest/RestUtilityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/rest/RestUtilityTest.java
@@ -1,0 +1,74 @@
+package uk.gov.ons.ctp.common.rest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.security.crypto.codec.Base64;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class RestUtilityTest {
+
+  private RestUtility restUtility =
+      new RestUtility(RestUtilityConfig.builder().username("user").password("password").build());
+
+    @Test
+    public void shouldAddAuthorizationHeaderWhenCreateHttpEntityWithAuthHeader() {
+        HttpEntity<Object> httpEntity = restUtility.createHttpEntityWithAuthHeader();
+
+        assertThat(httpEntity.getHeaders(), hasKey("Authorization"));
+        String authorizationHeader = httpEntity.getHeaders().getFirst("Authorization");
+        String base64UserPassword = StringUtils.substringAfter(authorizationHeader, "Basic ");
+        String usernamePassword =
+            new String(Base64.decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
+        assertEquals(usernamePassword, "user:password");
+    }
+
+    @Test
+    public void shouldAddJsonContentTypeHeaderWhenCreateHttpEntityWithAuthHeader() {
+        HttpEntity<Object> httpEntity = restUtility.createHttpEntityWithAuthHeader();
+
+        assertThat(httpEntity.getHeaders(), hasKey("Content-Type"));
+        assertEquals(httpEntity.getHeaders().getFirst("Content-Type"), "application/json");
+    }
+
+    @Test
+    public void shouldAddJsonAcceptHeaderWhenCreateHttpEntityWithAuthHeader() {
+        HttpEntity<Object> httpEntity = restUtility.createHttpEntityWithAuthHeader();
+
+        assertThat(httpEntity.getHeaders(), hasKey("Accept"));
+        assertEquals(httpEntity.getHeaders().getFirst("Accept"), "application/json");
+    }
+
+    @Test
+    public void shouldAddAuthorizationHeaderWhenCreateHttpEntity() {
+        HttpEntity<Object> httpEntity = restUtility.createHttpEntity(null);
+
+        assertThat(httpEntity.getHeaders(), hasKey("Authorization"));
+        String authorizationHeader = httpEntity.getHeaders().getFirst("Authorization");
+        String base64UserPassword = StringUtils.substringAfter(authorizationHeader, "Basic ");
+        String usernamePassword =
+            new String(Base64.decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
+        assertEquals(usernamePassword, "user:password");
+    }
+
+    @Test
+    public void shouldAddJsonContentTypeHeaderWhenCreateHttpEntity() {
+        HttpEntity<Object> httpEntity = restUtility.createHttpEntity(null);
+
+        assertThat(httpEntity.getHeaders(), hasKey("Content-Type"));
+        assertEquals(httpEntity.getHeaders().getFirst("Content-Type"), "application/json");
+    }
+
+    @Test
+    public void shouldAddJsonAcceptHeaderWhenCreateHttpEntity() {
+        HttpEntity<Object> httpEntity = restUtility.createHttpEntity(null);
+
+        assertThat(httpEntity.getHeaders(), hasKey("Accept"));
+        assertEquals(httpEntity.getHeaders().getFirst("Accept"), "application/json");
+    }
+}


### PR DESCRIPTION
# Motivation and Context
There are lots of occurrences where http GET requests are being made and basic authentication is needs to be set but no entity is added.


# What has changed
Create a method that will create an HttpEntity with Authorization
header set


# How to test?
Run unit tests
