### PR TITLE
Fix bug with inconsistent dates due to thread unsafe use DateFormat

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
@@ -3,14 +3,14 @@ package uk.gov.ons.ctp.common.jackson;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
+import java.text.SimpleDateFormat;
 
 /** Custom Object Mapper */
 public class CustomObjectMapper extends ObjectMapper {
 
   /** Custom Object Mapper Constructor */
   public CustomObjectMapper() {
-    this.setDateFormat(new MultiIsoDateFormat());
+    this.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
     this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     this.registerModule(new JavaTimeModule());
     this.findAndRegisterModules();

--- a/src/main/java/uk/gov/ons/ctp/common/util/AggregatedDateFormat.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/AggregatedDateFormat.java
@@ -21,7 +21,7 @@ public class AggregatedDateFormat extends DateFormat {
   private DateFormat[] inputFormats;
   private DateFormat outputFormat;
 
-  public AggregatedDateFormat(final DateFormat outputFormat, final DateFormat[] inputFormats) {
+  public void init(final DateFormat outputFormat, final DateFormat[] inputFormats) {
     this.inputFormats = inputFormats;
     this.outputFormat = outputFormat;
   }
@@ -35,7 +35,9 @@ public class AggregatedDateFormat extends DateFormat {
 
   @Override
   public Object clone() {
-    return new AggregatedDateFormat(this.outputFormat, this.inputFormats);
+    AggregatedDateFormat result = new AggregatedDateFormat();
+    result.init(this.outputFormat, this.inputFormats);
+    return result;
   }
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/common/util/MultiIsoDateFormat.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/MultiIsoDateFormat.java
@@ -21,7 +21,6 @@ public class MultiIsoDateFormat extends AggregatedDateFormat {
     DateFormat format3 = new SimpleDateFormat(ISO_FORMAT_3);
     DateFormat[] formats = {format1, format2, format3};
 
-
     init(format1, formats);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/util/MultiIsoDateFormat.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/MultiIsoDateFormat.java
@@ -10,16 +10,18 @@ import java.text.SimpleDateFormat;
  */
 public class MultiIsoDateFormat extends AggregatedDateFormat {
 
-  private static final DateFormat ISO_FORMAT_1 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-  private static final DateFormat ISO_FORMAT_2 =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
-  private static final DateFormat ISO_FORMAT_3 =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-
-  private static final DateFormat[] ALL_FORMATS = {ISO_FORMAT_1, ISO_FORMAT_2, ISO_FORMAT_3};
+  private static final String ISO_FORMAT_1 = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+  private static final String ISO_FORMAT_2 = "yyyy-MM-dd'T'HH:mm:ss.SSSXX";
+  private static final String ISO_FORMAT_3 = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
   /** Default constructor */
   public MultiIsoDateFormat() {
-    super(ISO_FORMAT_3, ALL_FORMATS);
+    DateFormat format1 = new SimpleDateFormat(ISO_FORMAT_1);
+    DateFormat format2 = new SimpleDateFormat(ISO_FORMAT_2);
+    DateFormat format3 = new SimpleDateFormat(ISO_FORMAT_3);
+    DateFormat[] formats = {format1, format2, format3};
+
+
+    init(format1, formats);
   }
 }


### PR DESCRIPTION
# Motivation and Context
We are seeing strange dates being returned by the Java Spring Boot REST APIs when there is a concurrency of 3 or 4 users hammering the endpoints. The dates are sometimes completely bogus (e.g. 30 February or 31 April). This is bad.

# What has changed
Updated rm-common-service shared classes `CustomObjectMapper` and `MultiIsoDateFormat` so that they no longer use `static` versions of a DateFormat object shared across threads which is *not thread safe*.

# How to test?
Bug can be reproduced by hammering collex events endpoint (e.g. `http://[host]:[port]/collectionexercises/[collex id]>/events`) and checking to make sure that a date such as the `exercise_end` date is *always* being returned as the expected correct value. This bug only occurs when there are *multiple concurrent users*.

# Links
Trello: https://trello.com/c/bGt4TX2Q/405-bug-dates