### PR TITLE
Restore multiple date format processing

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
@@ -3,14 +3,14 @@ package uk.gov.ons.ctp.common.jackson;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.text.SimpleDateFormat;
+import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
 
 /** Custom Object Mapper */
 public class CustomObjectMapper extends ObjectMapper {
 
   /** Custom Object Mapper Constructor */
   public CustomObjectMapper() {
-    this.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
+    this.setDateFormat(new MultiIsoDateFormat());
     this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     this.registerModule(new JavaTimeModule());
     this.findAndRegisterModules();

--- a/src/main/java/uk/gov/ons/ctp/common/util/MultiIsoDateFormat.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/MultiIsoDateFormat.java
@@ -16,11 +16,14 @@ public class MultiIsoDateFormat extends AggregatedDateFormat {
 
   /** Default constructor */
   public MultiIsoDateFormat() {
-    DateFormat format1 = new SimpleDateFormat(ISO_FORMAT_1);
-    DateFormat format2 = new SimpleDateFormat(ISO_FORMAT_2);
-    DateFormat format3 = new SimpleDateFormat(ISO_FORMAT_3);
-    DateFormat[] formats = {format1, format2, format3};
+    DateFormat outputFormat = new SimpleDateFormat(ISO_FORMAT_3);
 
-    init(format1, formats);
+    DateFormat inputFormat1 = new SimpleDateFormat(ISO_FORMAT_1);
+    DateFormat inputFormat2 = new SimpleDateFormat(ISO_FORMAT_2);
+    DateFormat inputFormat3 = new SimpleDateFormat(ISO_FORMAT_3);
+
+    DateFormat[] inputFormats = {inputFormat1, inputFormat2, inputFormat3};
+
+    init(outputFormat, inputFormats);
   }
 }


### PR DESCRIPTION
# Motivation and Context
Fix for the mangled dates was causing some regression problems with strange ISO8601 dates (e.g. `+0000`).

# What has changed
Restored backwards-compatible behaviour while also keeping the multithread safe code.

# How to test?
Full regression. Concurrent load testing. Prayers.

# Links
Trello: https://trello.com/c/bGt4TX2Q/405-bug-bad-dates-being-returned-by-java-services-under-load
