### PR TITLE
Use thread safe date formatter

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
@@ -3,14 +3,14 @@ package uk.gov.ons.ctp.common.jackson;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.text.SimpleDateFormat;
+import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
 
 /** Custom Object Mapper */
 public class CustomObjectMapper extends ObjectMapper {
 
   /** Custom Object Mapper Constructor */
   public CustomObjectMapper() {
-    this.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
+    this.setDateFormat(new MultiIsoDateFormat());
     this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     this.registerModule(new JavaTimeModule());
     this.findAndRegisterModules();

--- a/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/jackson/CustomObjectMapper.java
@@ -3,14 +3,14 @@ package uk.gov.ons.ctp.common.jackson;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
+import java.text.SimpleDateFormat;
 
 /** Custom Object Mapper */
 public class CustomObjectMapper extends ObjectMapper {
 
   /** Custom Object Mapper Constructor */
   public CustomObjectMapper() {
-    this.setDateFormat(new MultiIsoDateFormat());
+    this.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
     this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     this.registerModule(new JavaTimeModule());
     this.findAndRegisterModules();


### PR DESCRIPTION
# Motivation and Context
We are getting mangled dates when processing concurrent REST API requests, because the DateFormat class is not thread safe. Previous fixes have resolved this but reduced the amount of different timezone formats we could accept, possibly causing regression bugs.

# What has changed
The use of the `MultiIsoDateFormat` class for JSON marshalling and unmashalling has been restored. The `AggregatedDateFormat` class has been made robustly thread safe using `synchronized` blocks on the DateFormat objects which aren't thread safe.

# How to test?
Needs to be included in any of the Java Spring Boot REST API services, then repeatedly call an endpoint which returns multiple dates, from multiple clients concurrently - the issue happens about 1 in 500 times with 2 or 3 clients, processing hundreds of requests per second. This test has to be done using automation/scripting because it's so intermittent.

# Links
Trello: https://trello.com/c/q3Ijeoqy/414-bug-java-services-still-mangle-dates-under-concurrent-load